### PR TITLE
Prepend user message to ping

### DIFF
--- a/arrivebot.js
+++ b/arrivebot.js
@@ -26,7 +26,7 @@ export default function createArrivalBot(curr_attendees) {
             message.reply("Welcome " + message.author.username);
             await markPresent(message.author.username + "#" + message.author.discriminator, date);
 
-            const ping = curr_attendees.attendees_id.map(id => `<@${id}>`).join(" ");
+            let ping = curr_attendees.attendees_id.map(id => `<@${id}>`).join(" ");
 
             if (ping === "") {
                 ping = "No current attendees";


### PR DESCRIPTION
It'd be helpful for people to look at their phones and see the contents of the message in their notification tab, turning an exchange like

```
user: @doorman inner door
doorman: Welcome user
doorman: @person1 @person2 @person3
person1: which door?
person1: oh nvm
```

to

```
user: @doorman inner door
doorman: Welcome user
doorman: inner door @person1 @person2 @person3
person1: coming
```